### PR TITLE
Add FuseSoC .core file

### DIFF
--- a/hyperram.core
+++ b/hyperram.core
@@ -1,0 +1,13 @@
+CAPI=2:
+name : ::hyperram:0
+
+filesets:
+  rtl:
+    files:
+      - hyper_xface.v
+      - hyper_dword.v
+    file_type : verilogSource
+
+targets:
+  default:
+    filesets : [rtl]


### PR DESCRIPTION
Add FuseSoC .core file to make it easier to add the hyperram core as a dependency in FuseSoC-based projects